### PR TITLE
Make JavaScript canvas init less funky

### DIFF
--- a/templates/script.js
+++ b/templates/script.js
@@ -161,44 +161,44 @@ function PaintTask(resumeImage){
         // unterdruecke Kontextmenu vom canvas
         return false;  
     }
-    canvas.addEventListener("mousemove", function (e) {
-        mouseMove(e);        
-    }, false);
-    canvas.addEventListener("mousedown", function (e) {
-        mouseDown(e);
-    }, false);
-    canvas.addEventListener("mouseup", function (e) {
-        mouseUp(e);
-    }, false);
-    canvas.addEventListener("mouseout", function (e) {
-        mouseOut(e);
-    }, false);
+
+    function init() {
+        canvas.addEventListener("mousemove", function (e) {
+            mouseMove(e);
+        }, false);
+        canvas.addEventListener("mousedown", function (e) {
+            mouseDown(e);
+        }, false);
+        canvas.addEventListener("mouseup", function (e) {
+            mouseUp(e);
+        }, false);
+        canvas.addEventListener("mouseout", function (e) {
+            mouseOut(e);
+        }, false);
+    }
 
     //**********
     //********** weitere initialisierung
-    //**********        
-    
-	function resume(){
-		if (resumeImage){
-			var img = new Image;
-			img.src = resumeImage;
-			//img.onload = function(){
-				// zeichne abgabe
-				ctx.drawImage(img,0,0); 
-			//};
-			//img.src = resumeImage;			
-			pushDrawAction(); 
-			save(); // aufruf notwendig, da sonst 'nichts' als abgabe gespeichert wird
-		}
-	}
-	
-	window.onload = function()
-	{
-		// ist beides noetig, da sonst nicht immer 
-		// die gemachten zeichnungen dargestellt werden...
-		resume();
-		setTimeout(resume,500);
-	}
-        
-   // pushDrawAction(); 
+    //**********
+
+    function resume() {
+        if (resumeImage){
+            var img = new Image;
+            $(img).load(function() {
+                ctx.drawImage(img,0,0);
+                pushDrawAction();
+                save(); // aufruf notwendig, da sonst 'nichts' als abgabe gespeichert wird
+                init();
+            });
+            img.src = resumeImage;
+        } else {
+            init();
+        }
+    }
+
+    $(document).ready(function() {
+        resume();
+    });
+
+    // pushDrawAction();
 }


### PR DESCRIPTION
Behebt zwei Randfälle mit der momentanen Implementierung (1) momentan wird der Canvas doppelt und verzögert initialisiert; in seltenen Fällen führt dies zum Verlust des gespeicherten Bildes. (2) auch vor der Initialisierung ist schon ein Zeichnen in den Canvas möglich, was auch zum Verlust des zuvor gespeicherten Bildes führen kann.

Auf einem langsamen System sind beide Effekte (1) und (2) reproduzierbar:
[demo-without-pr.mov.zip](https://github.com/kyro46/assPaintQuestion/files/2764050/demo-without-pr.mov.zip)

Mit PR auf demselben System sind die Effekte nicht mehr reproduzierbar:
[demo-with-pr.mov.zip](https://github.com/kyro46/assPaintQuestion/files/2764051/demo-with-pr.mov.zip)
