### PR TITLE
Add alert on clear canvas action

### DIFF
--- a/templates/script.js
+++ b/templates/script.js
@@ -55,10 +55,12 @@ function PaintTask(resumeImage){
     }
 
     this.clear = function() {
-        // loesche den gesamten inhalt, hintergrundbild wird wieder vollstaendig angezeigt
-        ctx.clearRect(0,0,ctx.canvas.width,ctx.canvas.height);        
-        pushDrawAction();
-        textarea.value = '';
+        if (confirm('Alles löschen?')) {
+            // loesche den gesamten inhalt, hintergrundbild wird wieder vollstaendig angezeigt
+            ctx.clearRect(0,0,ctx.canvas.width,ctx.canvas.height);
+            pushDrawAction();
+            textarea.value = '';
+        }
     }
 
     this.erasePaint = function(button){


### PR DESCRIPTION
Fügt vor dem Löschen des Canvas eine Warnungsalert hinzu:

![alert](https://user-images.githubusercontent.com/25431384/51248076-48912400-198f-11e9-8f43-044751970137.png)

Zwar gibt es Undo, aber falls jemand löscht und speichert sind die Daten ja doch weg, daher fände ich persönlich eine solche Warnung trotzdem sinnvoll.

Bei Interesse kann ich auch eine international lokalisierte Version bauen.
