### PR TITLE
Limit maximum score to >= 1

### DIFF
--- a/classes/class.assPaintQuestionGUI.php
+++ b/classes/class.assPaintQuestionGUI.php
@@ -66,7 +66,7 @@ class assPaintQuestionGUI extends assQuestionGUI
 		// points
 		$points = new ilNumberInputGUI($plugin->txt("points"), "points");
 		$points->setSize(3);
-		$points->setMinValue(0);
+		$points->setMinValue(1);
 		$points->allowDecimals(1);
 		$points->setRequired(true);
 		$points->setValue($this->object->getPoints());


### PR DESCRIPTION
Da ja bereits in `assPaintQuestion::isComplete` eine Annahme stattfindet, dass die maximum score > 0 sein muss, sollte dies auch im UI-Feld konfiguriert sein. Momentan lässt sich trotz `isComplete() == false` eine Frage mit maximum score == 0 speichern und auch nutzen.