### PR TITLE
Don't destroy background image after iteration one

### DIFF
--- a/classes/class.assPaintQuestionGUI.php
+++ b/classes/class.assPaintQuestionGUI.php
@@ -569,7 +569,6 @@ class assPaintQuestionGUI extends assQuestionGUI
 						}
 						$image = ob_get_clean();
 						$base64 = base64_encode( $image );
-						imagedestroy($background);  
 						imagedestroy($drawing);
 					} else //only use the drawing
 					{
@@ -577,7 +576,8 @@ class assPaintQuestionGUI extends assQuestionGUI
 					} 
 				}
 				$template->setVariable("SOLUTION", ilUtil::prepareFormOutput($base64));		
-		}		
+		}
+		imagedestroy($background);
 
 		$template->setVariable("QUESTIONTEXT", $this->object->prepareTextareaOutput($output, TRUE));
 		


### PR DESCRIPTION
imagedestroy($background) is called after the first iteration but
possibly used in further iteration of user solutions.

Maybe tell your workmates that while keeping your question type plugins
up-to-date, you aren't maintaining ILIAS and Opencast anymore.
The impression I always get when talking to Rektorat or LLZ or even my
boss is that maintaining ILIAS is a matter of LLZ or you while debugging
questions frequently end up on my table.