### PR TITLE
Bugfix: Only destroy background if it exists

### DIFF
--- a/classes/class.assPaintQuestionGUI.php
+++ b/classes/class.assPaintQuestionGUI.php
@@ -577,7 +577,9 @@ class assPaintQuestionGUI extends assQuestionGUI
 				}
 				$template->setVariable("SOLUTION", ilUtil::prepareFormOutput($base64));		
 		}
-		imagedestroy($background);
+		if ($background) {
+			imagedestroy($background);
+		}
 
 		$template->setVariable("QUESTIONTEXT", $this->object->prepareTextareaOutput($output, TRUE));
 		


### PR DESCRIPTION
When I moved imagedestroy($background) out of the loop I missed the checks
running as a precondition to imagedestroy($background). It happens $background
to be null leading to

> imagedestroy() expects parameter 1 to be resource, null given in