### PR TITLE
Catch Warning when creating PNG

### DIFF
--- a/classes/class.assPaintQuestionGUI.php
+++ b/classes/class.assPaintQuestionGUI.php
@@ -497,7 +497,11 @@ class assPaintQuestionGUI extends assQuestionGUI
 					$background = imagecreatefromjpeg ($pathToImage);
 					break;
 				case 3:
+					set_error_handler(function ($errno, $errstr) {
+						ilLoggerFactory::getLogger('assPaintQuestion')->warning("Error $errno in Paint Question: $errstr");
+					}, E_WARNING);
 					$backgroundInput = imagecreatefrompng ($pathToImage);
+					restore_error_handler();
 					// Steps to convert transparency to white (instead of default black)
 					$backgroundWidth = imagesx($backgroundInput);
 					$backgroundHeight = imagesy($backgroundInput);


### PR DESCRIPTION
https://redmine.itz.uni-halle.de/issues/10510

Bei dem Tablet-Zeichenfragen-Prüfungstest wurde einen Hintergrundgrafik bei allen Fragen verwendet, die folgende Fehlermeldung hervorruft, wenn man sich die Antworten der TN anschauen möchte:

2 imagecreatefrompng(): gd-png: libpng warning: iCCP: known incorrect sRGB profile in /XXXXX/Customizing/global/plugins/Modules/TestQuestionPool/Questions/assPaintQuestion/classes/class.assPaintQuestionGUI.php:500
  #0 /var/www/ilias/Services/Init/classes/class.ilErrorHandling.php(526): Whoops\Run->handleError(2, 'imagecreatefrom...', '/var/www/ilias/...', 500)

Statistik > TN/detaillierte statsitik > Antwortenübersicht > error (z.B fehlercode 6c29c_5636 | 22.6. 11.07Uhr).
Export > Export inkl TN-ERgebnisse > ohne Antworten